### PR TITLE
fulltext search

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,15 @@ installed, you should automatically get:
 
 ## Deployment
 
-Handled automatically via Netlify. :tada:
+### Hosting
+
+Deployment is handled automatically via Netlify CI. :tada:
+
+### Full-text Search Indexing
+
+Search is handled via Algolia DocSearch, configuration changes must be made via
+PR to the [config file] (format [documentation]). Index is updated once every
+24 hrs.
+
+[config file]: https://github.com/algolia/docsearch-configs/blob/master/configs/openlaw.json
+[documentation]: https://community.algolia.com/docsearch/config-file.html

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -10,6 +10,10 @@ module.exports = {
       "/markup-language/"
       // add new top level sections here...
     ],
+    algolia: {
+      apiKey: "68c3c0d36676a3acce1cd3c7087bc7c9",
+      indexName: "openlaw"
+    },
     logo: "/ol-logo-black.svg",
     repo: "openlawteam/docs",
     docsDir: "docs",


### PR DESCRIPTION
I corresponded with the DocSearch team and we now have a free Algolia integration if we want it, changing our docs search from headers only to full text.

The index is automatically rebuilt every 24 hours, so it may be temporarily "stale" when we push changes.

This of course adds a minor amount of complexity to our setup, so wanted to create a preview for people to look at and decide whether it's worth while at this point.

Configuration file on DocSearch's side:
https://github.com/algolia/docsearch-configs/blob/master/configs/openlaw.json