### PR TITLE
fix github language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# GitHub's language detection attempts to auto-ignore documentation, but since
+# the purpose of this repository is documentation, we should distinguish between
+# the meta-docs for this repo, and the "content" itself.
+
+# Disable documentation flag for /docs directory
+docs/* linguist-documentation=false
+
+# Markdown files are considered "prose" rather than "markup", and thus not
+# detectable by default
+docs/**/*.md linguist-detectable=true


### PR DESCRIPTION
Documentation is ignored by default, but since our entire "content" is in the docs folder (by design), override in linguist settings.

I don't seem to be able to see this functioning live on GitHub when it's in a branch (maybe language is only calculated for master?), but I was able to test locally by building the latest version of github-linguist and running locally:

```
$ docker run --rm -v `pwd`:`pwd` -w `pwd` mrothy/linguist github-linguist --breakdown                                                                  
99.41%  Markdown
0.43%   JavaScript
0.16%   CSS

JavaScript:
docs/.vuepress/config.js

CSS:
docs/.vuepress/override.styl
docs/.vuepress/style.styl

Markdown:
docs/README.md
docs/api-client/README.md
docs/getting-started/README.md
docs/markup-language/README.md
docs/openlaw-core/README.md
docs/openlaw-object/README.md
docs/review-tool/README.md
```