### PR TITLE
disable multi-language feature (for now)

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -41,7 +41,7 @@ module.exports = {
     // Gets the UNIX timestamp(ms) of each file's last git commit, and it will also display at the bottom of each page in an appropriate format. The string will be displayed as a prefix.
     lastUpdated: "Last updated"
   },
-  locales: {
+  /* locales: {
     // The key is the path for the locale to be nested under.
     // As a special case, the default locale can use '/' as its path.
     '/': {
@@ -54,7 +54,7 @@ module.exports = {
       title: 'Documentación OpenLaw',
       description: 'Versión en español de la documentación de OpenLaw'
     }
-  }
+  } */
 };
 
 


### PR DESCRIPTION
We currently only have Spanish translated pages for `getting-started` and `markup-language`. The VuePress `locales` config applies the language selection feature for all pages so the result on any non-translated page is a 404 error (due to not having an es file for those) when trying to view that page in Spanish.

We'll comment out the `locales` config for now while we find a solution that will ideally allow us to have the 2 translated pages available and not have the other pages throw errors. If there is no option in VuePress to apply the language feature to only certain pages, then another option could be creating placeholder files for all the other pages in the `es` folder with content (in Spanish) indicating that the translated page is not yet available.

cc: @mapachurro 